### PR TITLE
Modify the EditText class with a better method approach

### DIFF
--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="EditText">
+        <attr name="prefix" format="string" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
Modify the EditText class by implementing styleable attributes. So, if you previously want to add a prefix in xml using **android:text** then you can replace it with **app:prefix**.

Function | Description
------------ | -------------
app:prefix="prefix" | add a prefix in xml
setPrefix(String prefix) | add a prefix in programmatically
getText() | get text input only (without prefix)
getCompletedText() | get the entire text (with a prefix)